### PR TITLE
도커 관련 경로 수정 및 백엔드 테스트 파일 임포트 경로 수정

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,4 +14,4 @@ COPY . .
 
 EXPOSE 8000
 
-CMD ["uvicorn", "test.test_main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.test.test_main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/test/test_main.py
+++ b/backend/app/test/test_main.py
@@ -3,12 +3,12 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from dotenv import load_dotenv
 
-from test.test_front import router as front_router
-from test.test_ml import router as ml_router
+from app.test.test_front import router as front_router
+from app.test.test_ml import router as ml_router
 
 load_dotenv()
 
-app = FastAPI(title="Integration Test Gateway")
+app = FastAPI(title="Integration Test Gateway", root_path="/api")
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/app/test/test_ml.py
+++ b/backend/app/test/test_ml.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from services.ml_client import ml_health, ml_classify
+from app.utils.ml_client import ml_health, ml_classify
 
 router = APIRouter()
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,7 +26,6 @@ services:
       - "8000:8000"
     volumes:
       - ./backend:/backendWorkspace
-    command: uvicorn test.test_main:app --host 0.0.0.0 --port 8000 --reload
     depends_on:
       - ml
       - mysql
@@ -39,7 +38,6 @@ services:
       - "9000:9000"
     volumes:
       - ./ml:/mlWorkspace
-    command: uvicorn test:app --host 0.0.0.0 --port 9000 --reload
 
   mysql:
     image: mysql:8.0

--- a/infra/nginx/local.conf
+++ b/infra/nginx/local.conf
@@ -2,7 +2,7 @@ server {
   listen 80;
 
   location / {
-    proxy_pass http://172.18.0.1:3000;
+    proxy_pass http://host.docker.internal:3000;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
 


### PR DESCRIPTION
## 🏷️ PR 유형 (Type)

- [x] Chore: 도커 컴포즈 파일명 및 중복 cmd 명령어 제거 & 백엔드 테스트 파일 임포트 경로 수정

---

## 🎯 관련 이슈 (Issue)

**Ref # [4]**

---

## 📝 주요 변경 사항 (Description & Detail)

### 1. 변경 배경 (Why)
- Stage 환경과 dev 환경이 분리됨에 따라 각기 다른 docker-compose파일 필요. 
- 현재 nginx - backend api 호출 확인을 위한 이전 테스트 코드 경로 문제로 인한 연동 실패 -> 이나님이 업로드한 기본 헬스체크로 수정 예정


### 2. 변경점 요약 (What)
- Team200/docker-compose.yml -> Team200/docker-compose.dev.yml  파일명 수정
- 각 파트의 Dockerfile에서 cmd 명령어 이미지화로 확정 -> compose 파일내 실행 cmd 삭제
- 백엔드 폴더 구조 변경에 따른 Dockerfile 및 test import 경로 수정
---

## 🧪 테스트 방법 및 결과 (How to Test)
1. 프로젝트 루트에서 docker compose -f docker-compose.dev.yml 실행 (Nginx, ml, backend, mysql 각각 컨테이너로 띄움)
2. 프론트엔드 폴더로 들어가서 npm run dev 실행
3. localhost -> 프론트 연결 확인
4. localhost/api/docs -> 백엔드 테스트 스웨거 확인