### PR TITLE
chore(infra): docker container 필요 환경변수 컨테이너 내부 주입

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,9 +19,10 @@ services:
       context: ./backend
     container_name: backend
     env_file:
-      - ./backend/.env.docker
+      - ./backend/.env
     environment:
       ML_BASE_URL: http://ml:9000
+      DB_HOST: mysql
     ports:
       - "8000:8000"
     volumes:


### PR DESCRIPTION
- 팀장님과의 상의에 따라 .env 파일을 굳이 2개로 나눌 필요가 없다고 판단하여, 컨테이너 내부에 변경되어야하는 환경변수를 주입해두었습니다~